### PR TITLE
Changes for php 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,27 @@ jobs:
       - name: Run tests
         run: ./vendor/bin/phpunit --testsuite Unit
 
+  build80:
+    name: Build PHP 8.0
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 10
+
+    steps:
+      - name: Set up PHP
+        uses: shivammathur/setup-php@2.1.0
+        with:
+          php-version: 8.0
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Download dependencies
+        run: composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
+
+      - name: Run tests
+        run: ./vendor/bin/phpunit --testsuite Unit
+
   integration:
     name: Integration tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       max-parallel: 10
       matrix:
-        php: ['7.2', '7.3', '7.4']
+        php: ['7.2', '7.3', '7.4', '8.0']
         sf_version: ['3.4.*', '4.4.*', '5.0.*']
 
     steps:
@@ -52,27 +52,6 @@ jobs:
       - name: Download dependencies
         env:
           SYMFONY_REQUIRE: ${{ matrix.sf_version }}
-        run: composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
-
-      - name: Run tests
-        run: ./vendor/bin/phpunit --testsuite Unit
-
-  build80:
-    name: Build PHP 8.0
-    runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 10
-
-    steps:
-      - name: Set up PHP
-        uses: shivammathur/setup-php@2.1.0
-        with:
-          php-version: 8.0
-
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Download dependencies
         run: composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@2.1.0
         with:
-          php-version: 7.3
+          php-version: 7.4
           tools: flex
 
       - name: Checkout code

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -42,6 +42,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Psalm
-        uses: docker://muglug/psalm-github-actions
+        uses: docker://vimeo/psalm-github-actions
         with:
           args: --no-progress --show-info=false --stats

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-fpm-stretch
+FROM php:7.4-fpm-buster
 
 # Install Nginx
 RUN apt-get update -qq && apt-get install -y --no-install-recommends -qq nginx

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "^7.1|^8.0",
+        "php": "^7.1 || ^8.0",
         "psr/http-message": "^1.0",
         "psr/http-client": "^1.0",
         "php-http/httplug": "^1.1 || ^2.0",
@@ -26,10 +26,10 @@
         "psr/http-factory": "^1.0"
     },
     "require-dev": {
-        "php-http/client-integration-tests": "^3.0.0",
+        "php-http/client-integration-tests": "^3.0",
         "nyholm/psr7": "^1.0",
         "psr/log": "^1.0",
-        "phpunit/phpunit": "7.5.20|9.4.1"
+        "phpunit/phpunit": "^7.5 || ^9.4"
     },
     "provide": {
         "php-http/client-implementation": "1.0",

--- a/composer.json
+++ b/composer.json
@@ -48,5 +48,8 @@
         "psr-4": {
             "Buzz\\Test\\": "tests"
         }
+    },
+    "conflict": {
+        "symfony/polyfill-php80": "*"
     }
 }

--- a/lib/Client/AbstractClient.php
+++ b/lib/Client/AbstractClient.php
@@ -13,7 +13,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 abstract class AbstractClient
 {
     /**
-     * @var OptionsResolver
+     * @var OptionsResolver|null
      */
     private $optionsResolver;
 

--- a/lib/Client/MultiCurl.php
+++ b/lib/Client/MultiCurl.php
@@ -56,7 +56,13 @@ class MultiCurl extends AbstractCurl implements BatchClientInterface, BuzzClient
     {
         parent::__construct($responseFactory, $options);
 
-        if (\PHP_VERSION_ID < 70215 || \PHP_VERSION_ID === 70300 || \PHP_VERSION_ID === 70301 || !(CURL_VERSION_HTTP2 & curl_version()['features'])) {
+        if (
+            \PHP_VERSION_ID < 70215 ||
+            \PHP_VERSION_ID === 70300 ||
+            \PHP_VERSION_ID === 70301 ||
+            \PHP_VERSION_ID >= 80000 ||
+            !(CURL_VERSION_HTTP2 & curl_version()['features'])
+        ) {
             // Dont use HTTP/2 push when it's unsupported or buggy, see https://bugs.php.net/76675
             $this->serverPushSupported = false;
         }

--- a/tests/Integration/MultiCurlServerPushTest.php
+++ b/tests/Integration/MultiCurlServerPushTest.php
@@ -13,7 +13,7 @@ class MultiCurlServerPushTest extends BaseIntegrationTest
     protected function setUp(): void
     {
         parent::setUp();
-        if (\PHP_VERSION_ID < 70400 || curl_version()['version_number'] < 472065) {
+        if (\PHP_VERSION_ID < 70400 || \PHP_VERSION_ID >= 80000 || curl_version()['version_number'] < 472065) {
             $this->markTestSkipped('This environment does not support server push');
         }
     }

--- a/tests/Unit/Middleware/LoggerMiddlewareTest.php
+++ b/tests/Unit/Middleware/LoggerMiddlewareTest.php
@@ -19,8 +19,14 @@ class LoggerMiddlewareTest extends TestCase
 
         // TODO Use PSR3 logger
         $logger = new CallbackLogger(function ($level, $message, array $context) use ($that) {
-            $method = method_exists($that, 'assertRegExp') ? 'assertRegExp' : 'assertMatchesRegularExpression';
-            $that->$method('~^Sent "GET http://google.com/" in \d+ms$~', $message);
+            $pattern = '~^Sent "GET http://google.com/" in \d+ms$~';
+            if (method_exists($this, 'assertMatchesRegularExpression')) {
+                $that->assertMatchesRegularExpression($pattern, $message);
+
+                return;
+            }
+            // phpunit 7 compatibility
+            $that->assertRegExp($pattern, $message);
         });
 
         $request = new Request('GET', 'http://google.com/');

--- a/tests/Unit/Middleware/WsseAuthMiddlewareTest.php
+++ b/tests/Unit/Middleware/WsseAuthMiddlewareTest.php
@@ -22,7 +22,13 @@ class WsseAuthMiddlewareTest extends TestCase
 
         $this->assertEquals('WSSE profile="UsernameToken"', $newRequest->getHeaderLine('Authorization'));
         $wsse = $newRequest->getHeaderLine('X-WSSE');
-        $method = method_exists($this, 'assertRegExp') ? 'assertRegExp' : 'assertMatchesRegularExpression';
-        $this->$method('|UsernameToken Username="foo", PasswordDigest=".+?", Nonce=".+?", Created=".+?"|', $wsse);
+        $pattern = '|UsernameToken Username="foo", PasswordDigest=".+?", Nonce=".+?", Created=".+?"|';
+        if (method_exists($this, 'assertMatchesRegularExpression')) {
+            $this->assertMatchesRegularExpression($pattern, $wsse);
+
+            return;
+        }
+        // phpunit 7 compatibility
+        $this->assertRegExp($pattern, $wsse);
     }
 }


### PR DESCRIPTION
Hi @sunkan,

as already mentioned in https://github.com/kriswallsmith/Buzz/pull/417, here the pull request to combine forces in order to get Buzz php 8 compatible. Just some notes:

* due to some strange curl behaviour under php 8, the multi curl server push mechanism had to be disabled for php 8. That's something someone needs to check in another pull request
* due to the combination of different symfony packages, I had to set the package `symfony/polyfill-php80` as conflict so it will be ignored for installation (credits: https://github.com/laravel/framework/issues/33045#issuecomment-660183170)
* the CI build `HTTP/2 Server Push` had to be changed to php 7.4, as the referenced docker image `tommymuehle/docker-alpine-php-nightly` is already using php 7.4, but that's not a problem for that build anyway, as the server push is comptible to the php versions `^7.3.2 || ^7.4`
* I slightly modified your `method_exists` construct on two unit tests to eliminate some phpunit warnings

Other than that I was able to get all builds green : )